### PR TITLE
Core api updates

### DIFF
--- a/src/scripts/common/forms/warn-button.jsx
+++ b/src/scripts/common/forms/warn-button.jsx
@@ -129,7 +129,10 @@ export default class WarnButton extends React.Component {
 
         if (typeof action === 'function') {
             this.setState({loading: true});
-            action(() => {
+            action((e) => {
+                if (e && e.error) {
+                    notifications.createAlert({type: 'Error', message: e.error});
+                }
                 if (this._mounted) {
                     this.setState({loading: false, showAction: !this.state.showAction});
                 }

--- a/src/scripts/dataset/dataset.store.js
+++ b/src/scripts/dataset/dataset.store.js
@@ -263,7 +263,7 @@ let datasetStore = Reflux.createStore({
      * download feedback.
      */
     trackDownload(callback) {
-        scitran.trackUsage(this.data.dataset._id, 'download', () => {
+        scitran.trackUsage(this.data.dataset._id, 'download', {snapshot: true}, () => {
             let dataset = this.data.dataset;
             dataset.downloads++;
             this.update({dataset});
@@ -1006,7 +1006,7 @@ let datasetStore = Reflux.createStore({
     // usage analytics ---------------------------------------------------------------
 
     trackView (snapshotId) {
-        scitran.trackUsage(snapshotId, 'view', () => {});
+        scitran.trackUsage(snapshotId, 'view', {snapshot: true}, () => {});
     },
 
     // Toggle Sidebar ----------------------------------------------------------------

--- a/src/scripts/dataset/dataset.store.js
+++ b/src/scripts/dataset/dataset.store.js
@@ -431,8 +431,11 @@ let datasetStore = Reflux.createStore({
      * Update README
      */
     updateREADME(value, callback) {
+        let dataset = this.data.dataset;
         scitran.updateFileFromString('projects', this.data.dataset._id, 'README', value, '', [], (err, res) => {
             callback(err, res);
+            dataset.README = value;
+            this.update({dataset});
             this.updateModified();
         });
     },
@@ -949,7 +952,7 @@ let datasetStore = Reflux.createStore({
                 callback({error: 'You cannot snapshot an invalid dataset. Please fix the errors and try again.'});
             } else {
                 let latestSnapshot = this.data.snapshots[1];
-                if (latestSnapshot && (moment(project.modified).diff(moment(latestSnapshot.modified)) <= 0)) {
+                if (latestSnapshot && (moment(this.data.dataset.modified).diff(moment(latestSnapshot.modified)) <= 0)) {
                     callback({error: 'No modifications have been made since the last snapshot was created. Please use the most recent snapshot.'});
                 } else {
                     scitran.createSnapshot(datasetId, (err, res) => {

--- a/src/scripts/utils/bids.js
+++ b/src/scripts/utils/bids.js
@@ -275,6 +275,7 @@ export default  {
      * containers.
      */
     deleteDataset (projectId, callback, options) {
+        options.query = {purge: true};
         scitran.deleteContainer('projects', projectId, callback, options);
     },
 

--- a/src/scripts/utils/bids.js
+++ b/src/scripts/utils/bids.js
@@ -449,9 +449,9 @@ export default  {
     usage (snapshotId, options, callback) {
         if (options && options.snapshot) {
             let usage = {};
-            scitran.getUsage(snapshotId, {type: 'view', count: true}, (err, res) => {
+            scitran.getUsage(snapshotId, {query: {type: 'view', count: true}, snapshot: true}, (err, res) => {
                 usage.views = res.body.count;
-                scitran.getUsage(snapshotId, {type: 'download', count: true}, (err1, res1) => {
+                scitran.getUsage(snapshotId, {query: {type: 'download', count: true}, snapshot: true}, (err1, res1) => {
                     usage.downloads = res1.body.count;
                     callback(usage);
                 });

--- a/src/scripts/utils/bids.js
+++ b/src/scripts/utils/bids.js
@@ -238,7 +238,7 @@ export default  {
                         callback([dataset]);
                     });
                 });
-            });
+            }, options);
         }, options);
     },
 
@@ -275,25 +275,7 @@ export default  {
      * containers.
      */
     deleteDataset (projectId, callback, options) {
-        if (!options.snapshot) {
-            scitran.getSessions(projectId, (sessions) => {
-                async.each(sessions, (session, cb) => {
-                    scitran.getAcquisitions(session._id, (acquisitions) => {
-                        async.each(acquisitions, (acquisition, cb1) => {
-                            scitran.deleteContainer('acquisitions', acquisition._id, cb1);
-                        }, () => {
-                            scitran.deleteContainer('sessions', session._id, cb);
-                        });
-                    });
-                }, () => {
-                    crn.deleteDatasetJobs(projectId, () => {
-                        scitran.deleteContainer('projects', projectId, callback);
-                    });
-                });
-            });
-        } else {
-            scitran.deleteSnapshot(projectId, callback);
-        }
+        scitran.deleteContainer('projects', projectId, callback, options);
     },
 
 // Dataset Format Helpers -----------------------------------------------------------------

--- a/src/scripts/utils/crn.js
+++ b/src/scripts/utils/crn.js
@@ -46,7 +46,7 @@ export default {
      * Un Blacklist
      */
     unBlacklistUser(userId, callback) {
-        request.del(config.crn.url + 'users/blacklist/' + userId, callback);
+        request.del(config.crn.url + 'users/blacklist/' + userId, {}, callback);
     },
 
 // Jobs ------------------------------------------------------------------------------------
@@ -113,7 +113,7 @@ export default {
      * Delete Dataset Jobs
      */
     deleteDatasetJobs(datasetId, callback) {
-        request.del(config.crn.url + 'datasets/' + datasetId + '/jobs', callback);
+        request.del(config.crn.url + 'datasets/' + datasetId + '/jobs', {}, callback);
     },
 
 // Validation ------------------------------------------------------------------------------

--- a/src/scripts/utils/request.js
+++ b/src/scripts/utils/request.js
@@ -93,13 +93,13 @@ var Request = {
  */
 function handleRequest (url, options, callback) {
 
+    // normalize options to play nice with superagent requests
+    options = normalizeOptions(options);
+
     // add snapshot url param to scitran requests
     if (options.snapshot && url.indexOf(config.scitran.url) > -1) {
         url = config.scitran.url + 'snapshots/' + url.slice(config.scitran.url.length);
     }
-
-    // normalize options to play nice with superagent requests
-    options = normalizeOptions(options);
 
     // verify access token before authenticated requests
     if (options.auth && hasToken() && (url.indexOf(config.scitran.url) > -1 || url.indexOf(config.crn.url) > -1)) {
@@ -131,6 +131,7 @@ function handleResponse (err, res, callback) {
  * normalizes it so requests won't fail.
  */
 function normalizeOptions (options) {
+    options = options ? options : {};
     if (!options.headers) {options.headers = {};}
     if (!options.query)   {options.query   = {};}
     if (!options.hasOwnProperty('auth')) {options.auth = true;}

--- a/src/scripts/utils/request.js
+++ b/src/scripts/utils/request.js
@@ -46,7 +46,7 @@ var Request = {
         });
     },
 
-    del (url, callback) {
+    del (url, options, callback) {
         handleRequest(url, {}, function (url, options) {
             request.del(url)
                 .set(options.headers)

--- a/src/scripts/utils/request.js
+++ b/src/scripts/utils/request.js
@@ -47,7 +47,7 @@ var Request = {
     },
 
     del (url, options, callback) {
-        handleRequest(url, {}, function (url, options) {
+        handleRequest(url, options, function (url, options) {
             request.del(url)
                 .set(options.headers)
                 .query(options.query)

--- a/src/scripts/utils/request.js
+++ b/src/scripts/utils/request.js
@@ -88,9 +88,20 @@ var Request = {
  *   - body: A http request body.
  *   - auth: A boolean determining whether the access token
  *   should be supplied with the request.
+ *   - snapshot: A boolean that will add a 'snapshots' url
+ *   param to scitran requests.
  */
 function handleRequest (url, options, callback) {
+
+    // add snapshot url param to scitran requests
+    if (options.snapshot && url.indexOf(config.scitran.url) > -1) {
+        url = config.scitran.url + 'snapshots/' + url.slice(config.scitran.url.length);
+    }
+
+    // normalize options to play nice with superagent requests
     options = normalizeOptions(options);
+
+    // verify access token before authenticated requests
     if (options.auth && hasToken() && (url.indexOf(config.scitran.url) > -1 || url.indexOf(config.crn.url) > -1)) {
         if (window.localStorage.scitranUser && JSON.parse(window.localStorage.scitranUser).root) {options.query.root = true;}
         userActions.checkAuth((token) => {

--- a/src/scripts/utils/scitran.js
+++ b/src/scripts/utils/scitran.js
@@ -209,6 +209,16 @@ export default  {
     },
 
     /**
+     * Get Project Acquisitions
+     */
+    getProjectAcquisitions (projectId, callback, options) {
+        let modifier = options && options.snapshot ? 'snapshots/' : '';
+        request.get(config.scitran.url + modifier + 'projects/' + projectId + '/acquisitions', {}, (err, res) => {
+            callback(res.body);
+        });
+    },
+
+    /**
      * Get Acquisitions
      *
      */

--- a/src/scripts/utils/scitran.js
+++ b/src/scripts/utils/scitran.js
@@ -163,12 +163,9 @@ export default  {
      *
      */
     getProjects (options, callback) {
-        let auth = options.hasOwnProperty('authenticate') ? options.authenticate : true;
-        let modifier = options && options.snapshot ? 'snapshots/' : '';
-        request.get(config.scitran.url + modifier + 'projects', {
-            auth,
-            query: {metadata: !!options.metadata}
-        }, (err, res) => {
+        options.auth = options.hasOwnProperty('authenticate') ? options.authenticate : true;
+        options.query = {metadata: !!options.metadata};
+        request.get(config.scitran.url + 'projects', options, (err, res) => {
             callback(res.body);
         });
     },
@@ -178,8 +175,7 @@ export default  {
      *
      */
     getProject (projectId, callback, options) {
-        let modifier = options && options.snapshot ? 'snapshots/' : '';
-        request.get(config.scitran.url + modifier + 'projects/' + projectId, {}, (err, res) => {
+        request.get(config.scitran.url + 'projects/' + projectId, options, (err, res) => {
             callback(res);
         });
     },
@@ -189,10 +185,8 @@ export default  {
      *
      */
     getSessions (projectId, callback, options) {
-        let modifier = options && options.snapshot ? 'snapshots/' : '';
-        request.get(config.scitran.url + modifier + 'projects/' + projectId + '/sessions', {
-            query: {public: true}
-        }, (err, res) => {
+        options.query = {public: true};
+        request.get(config.scitran.url + 'projects/' + projectId + '/sessions', options, (err, res) => {
             callback(res.body);
         });
     },
@@ -202,8 +196,7 @@ export default  {
      *
      */
     getSession (sessionId, callback, options) {
-        let modifier = options && options.snapshot ? 'snapshots/' : '';
-        request.get(config.scitran.url + modifier + 'sessions/' + sessionId, {}, (err, res) => {
+        request.get(config.scitran.url + 'sessions/' + sessionId, options, (err, res) => {
             callback(res.body);
         });
     },
@@ -212,8 +205,7 @@ export default  {
      * Get Project Acquisitions
      */
     getProjectAcquisitions (projectId, callback, options) {
-        let modifier = options && options.snapshot ? 'snapshots/' : '';
-        request.get(config.scitran.url + modifier + 'projects/' + projectId + '/acquisitions', {}, (err, res) => {
+        request.get(config.scitran.url + 'projects/' + projectId + '/acquisitions', options, (err, res) => {
             callback(res.body);
         });
     },
@@ -223,10 +215,8 @@ export default  {
      *
      */
     getAcquisitions (sessionId, callback, options) {
-        let modifier = options && options.snapshot ? 'snapshots/' : '';
-        request.get(config.scitran.url + modifier + 'sessions/' + sessionId + '/acquisitions', {
-            query: {public: true}
-        }, (err, res) => {
+        options.query = {public: true};
+        request.get(config.scitran.url + 'sessions/' + sessionId + '/acquisitions', options, (err, res) => {
             callback(res.body);
         });
     },
@@ -236,8 +226,7 @@ export default  {
      *
      */
     getAcquisition (acquisitionId, callback, options) {
-        let modifier = options && options.snapshot ? 'snapshots/' : '';
-        request.get(config.scitran.url  + modifier + 'acquisitions/' + acquisitionId, {}, (err, res) => {
+        request.get(config.scitran.url  + 'acquisitions/' + acquisitionId, options, (err, res) => {
             callback(res.body);
         });
     },
@@ -247,8 +236,7 @@ export default  {
      *
      */
     getFile (level, id, filename, callback, options) {
-        let modifier = options && options.snapshot ? 'snapshots/' : '';
-        request.get(config.scitran.url + modifier + level + '/' + id + '/files/' + filename, {}, callback);
+        request.get(config.scitran.url + level + '/' + id + '/files/' + filename, options, callback);
     },
 
     /**
@@ -256,10 +244,8 @@ export default  {
      *
      */
     getDownloadTicket (level, id, filename, callback, options) {
-        let modifier = options && options.snapshot ? 'snapshots/' : '';
-        request.get(config.scitran.url + modifier + level + '/' + id + '/files/' + filename, {
-            query: {ticket: ''}
-        }, callback);
+        options.query = {ticket: ''};
+        request.get(config.scitran.url + level + '/' + id + '/files/' + filename, options, callback);
     },
 
     /**
@@ -267,16 +253,12 @@ export default  {
      *
      */
     getBIDSDownloadTicket (projectId, callback, options) {
-        let modifier = options && options.snapshot ? 'snapshots/' : '';
-        request.post(config.scitran.url + modifier + 'download', {
-            query: {format: 'bids'},
-            body: {
-                nodes:[
-                    {_id: projectId, level: 'project'}
-                ],
-                optional: false
-            }
-        }, callback);
+        options.query = {format: 'bids'};
+        options.body = {
+            nodes:[{_id: projectId, level: 'project'}],
+            optional: false
+        };
+        request.post(config.scitran.url + 'download', options, callback);
     },
 
 // Delete ---------------------------------------------------------------------------------
@@ -287,8 +269,7 @@ export default  {
      */
     deleteContainer (type, id, callback, options) {
         options = options ? options : {};
-        let modifier = options && options.snapshot ? 'snapshots/' : '';
-        request.del(config.scitran.url + modifier + type + '/' + id + '?purge=true', options, callback);
+        request.del(config.scitran.url + type + '/' + id + '?purge=true', options, callback);
     },
 
     /**

--- a/src/scripts/utils/scitran.js
+++ b/src/scripts/utils/scitran.js
@@ -60,7 +60,7 @@ export default  {
      * Takes a userId and removes the user.
      */
     removeUser (userId, callback) {
-        request.del(config.scitran.url + 'users/' + userId, (err, res) => {
+        request.del(config.scitran.url + 'users/' + userId, {}, (err, res) => {
             callback(err, res);
         });
     },
@@ -286,8 +286,9 @@ export default  {
      *
      */
     deleteContainer (type, id, callback, options) {
+        options = options ? options : {};
         let modifier = options && options.snapshot ? 'snapshots/' : '';
-        request.del(config.scitran.url + modifier + type + '/' + id + '?purge=true', callback);
+        request.del(config.scitran.url + modifier + type + '/' + id + '?purge=true', options, callback);
     },
 
     /**
@@ -295,21 +296,21 @@ export default  {
      *
      */
     deleteFile (level, containerId, filename, callback) {
-        request.del(config.scitran.url + level + '/' + containerId + '/files/' + filename, callback);
+        request.del(config.scitran.url + level + '/' + containerId + '/files/' + filename, {}, callback);
     },
 
     /**
      * Remove Tag
      */
     removeTag (containerType, containerId, tag, callback) {
-        request.del(config.scitran.url + containerType + '/' + containerId + '/tags/' + tag, callback);
+        request.del(config.scitran.url + containerType + '/' + containerId + '/tags/' + tag, {}, callback);
     },
 
     /**
      * Remove Permission
      */
     removePermission (container, id, userId, callback) {
-        request.del(config.scitran.url + container + '/' + id + '/permissions/local/' + userId, callback);
+        request.del(config.scitran.url + container + '/' + id + '/permissions/local/' + userId, {}, callback);
     },
 
 // Update ---------------------------------------------------------------------------------

--- a/src/scripts/utils/scitran.js
+++ b/src/scripts/utils/scitran.js
@@ -285,8 +285,9 @@ export default  {
      * Delete Container
      *
      */
-    deleteContainer (type, id, callback) {
-        request.del(config.scitran.url + type + '/' + id, callback);
+    deleteContainer (type, id, callback, options) {
+        let modifier = options && options.snapshot ? 'snapshots/' : '';
+        request.del(config.scitran.url + modifier + type + '/' + id + '?purge=true', callback);
     },
 
     /**
@@ -366,10 +367,6 @@ export default  {
         request.get(config.scitran.url + 'projects/' + projectId + '/snapshots', {
             query: {public: true}
         }, callback);
-    },
-
-    deleteSnapshot (projectId, callback) {
-        request.del(config.scitran.url + 'snapshots/projects/' + projectId, callback);
     },
 
     updateSnapshotPublic(projectId, value, callback) {

--- a/src/scripts/utils/scitran.js
+++ b/src/scripts/utils/scitran.js
@@ -364,10 +364,9 @@ export default  {
      *
      * - type ('view' or 'download')
      */
-    trackUsage (snapshotId, type, callback) {
-        request.post(config.scitran.url + 'snapshots/projects/' + snapshotId + '/analytics', {
-            query: {type}
-        }, callback);
+    trackUsage (snapshotId, type, options, callback) {
+        options.query = {type}
+        request.post(config.scitran.url + 'projects/' + snapshotId + '/analytics', options, callback);
     },
 
     /**
@@ -382,9 +381,7 @@ export default  {
      * - limit      (integer)
      */
     getUsage (snapshotId, options, callback) {
-        request.get(config.scitran.url + 'snapshots/projects/' + snapshotId + '/analytics', {
-            query: options
-        }, callback);
+        request.get(config.scitran.url + 'projects/' + snapshotId + '/analytics', options, callback);
     }
 
 };


### PR DESCRIPTION
Takes advantage of recent API changes.
- delete a snapshot or dataset with a single requests
- load any dataset/snapshot with 3 requests

Simplified / Normalized core api
- Don't require snapshot modifier logic on every endpoint
- Support request options more consistently across endpoints and request methods

Fixed bugs
- README was not updating in UI after changes
- Changes to README were not allowing a new snapshot to be created
