### PR TITLE
Adding Parameter Metadata to Job forms

### DIFF
--- a/src/scripts/admin/admin.create-job.modal.jsx
+++ b/src/scripts/admin/admin.create-job.modal.jsx
@@ -37,7 +37,9 @@ const CreateJob = React.createClass({
                                          onChange={this._handleChange.bind(null, 'parameters')}
                                          model={[
                                              {id: 'key', placeholder: 'Key', required: true},
-                                             {id: 'defaultValue', placeholder: 'default value'}
+                                             {id: 'defaultValue', placeholder: 'default value'},
+                                             {id: 'type', placeholder: 'Parameter Type'},
+                                             {id: 'description', placeholder: 'Parameter Description'}
                                          ]} />
                         </div>
                         <button className="btn-modal-submit" onClick={actions.submitJobDefinition}>

--- a/src/scripts/admin/admin.create-job.modal.jsx
+++ b/src/scripts/admin/admin.create-job.modal.jsx
@@ -25,11 +25,12 @@ const CreateJob = React.createClass({
                 <hr className="modal-inner" />
                 <Modal.Body>
                     <div>
-                        <Input placeholder="Job Definition Name"     value={definition.name}           name={'name'}           onChange={this._inputChange} disabled={!!definition.edit}/>
-                        <Input placeholder="Bids Container"          value={definition.containerImage} name={'containerImage'} onChange={this._inputChange} />
-                        <Input placeholder="Host Container"          value={definition.hostImage}      name={'hostImage'}      onChange={this._inputChange} />
-                        <Input placeholder="vCPUs"                   value={definition.vcpus}          name={'vcpus'}          onChange={this._inputChange} />
-                        <Input placeholder="Memory (MiB)"            value={definition.memory}         name={'memory'}         onChange={this._inputChange} />
+                        <Input placeholder="Job Definition Name"        value={definition.name}           name={'name'}           onChange={this._inputChange} disabled={!!definition.edit}/>
+                        <Input placeholder="Job Definition Description" value={definition.description} name={'description'} onChange={this._inputChange} />
+                        <Input placeholder="Bids Container"             value={definition.containerImage} name={'containerImage'} onChange={this._inputChange} />
+                        <Input placeholder="Host Container"             value={definition.hostImage}      name={'hostImage'}      onChange={this._inputChange} />
+                        <Input placeholder="vCPUs"                      value={definition.vcpus}          name={'vcpus'}          onChange={this._inputChange} />
+                        <Input placeholder="Memory (MiB)"               value={definition.memory}         name={'memory'}         onChange={this._inputChange} />
                         <div className="form-group">
                              <label>Parameters</label>
                              <ArrayInput value={definition.parameters}

--- a/src/scripts/admin/admin.store.js
+++ b/src/scripts/admin/admin.store.js
@@ -5,8 +5,8 @@ import Actions   from './admin.actions.js';
 import scitran   from '../utils/scitran';
 import crn       from '../utils/crn';
 import batch     from '../utils/batch';
+import datasetActions from '../dataset/dataset.actions';
 
-import datasetStore from '../dataset/dataset.store';
 
 let UserStore = Reflux.createStore({
 
@@ -291,7 +291,7 @@ let UserStore = Reflux.createStore({
 
         crn.defineJob(jobDefinition, () => {
             // TODO - error handling
-            datasetStore.loadApps(); //this does not seem like the right way to do this.
+            datasetActions.loadApps(); //this does not seem like the right way to do this.
             console.log('job submitted');
             //toggle modal once response comes bacn from server.
             this.toggleModal('defineJob');

--- a/src/scripts/admin/admin.store.js
+++ b/src/scripts/admin/admin.store.js
@@ -6,6 +6,8 @@ import scitran   from '../utils/scitran';
 import crn       from '../utils/crn';
 import batch     from '../utils/batch';
 
+import datasetStore from '../dataset/dataset.store';
+
 let UserStore = Reflux.createStore({
 
 // store setup -----------------------------------------------------------------------
@@ -63,7 +65,8 @@ let UserStore = Reflux.createStore({
                 vcpus: '1',
                 memory: '2000',
                 parameters: [],
-                edit: false
+                edit: false,
+                description: ''
             },
             blacklistError: ''
         };
@@ -282,9 +285,16 @@ let UserStore = Reflux.createStore({
         }
         jobDefinition.parameters = parameters;
 
+        jobDefinition.descriptions = {
+            description: formData.description
+        };
+
         crn.defineJob(jobDefinition, () => {
-            // TODO - update our list of jobs
+            // TODO - error handling
+            datasetStore.loadApps(); //this does not seem like the right way to do this.
             console.log('job submitted');
+            //toggle modal once response comes bacn from server.
+            this.toggleModal('defineJob');
         });
     },
 
@@ -309,6 +319,7 @@ let UserStore = Reflux.createStore({
         let jobDefinitionForm = this.data.jobDefinitionForm;
         jobDefinitionForm.edit = true;
         jobDefinitionForm.name = jobDefinition.jobDefinitionName;
+        jobDefinitionForm.description = jobDefinition.descriptions && jobDefinition.descriptions.description ? jobDefinition.descriptions.description : '';
         jobDefinitionForm.jobRoleArn = jobDefinition.jobDefinitionArn;
         jobDefinitionForm.containerImage = batch.getBidsContainer(jobDefinition);
         jobDefinitionForm.hostImage = jobDefinition.containerProperties.image;
@@ -333,6 +344,7 @@ let UserStore = Reflux.createStore({
             hostImage: '',
             command: '',
             vcpus: '1',
+            description: '',
             memory: '2000',
             parameters: [],
             edit: false

--- a/src/scripts/admin/admin.store.js
+++ b/src/scripts/admin/admin.store.js
@@ -263,6 +263,7 @@ let UserStore = Reflux.createStore({
         // Build up the AWS object
         let jobDefinition = {};
         let parameters = {};
+        let parametersMetadata = {};
 
         jobDefinition.jobDefinitionName = formData.name;
         // Container is the only supported type by AWS Batch API as of now.
@@ -277,13 +278,16 @@ let UserStore = Reflux.createStore({
                 {name: 'BIDS_CONTAINER', value: formData.containerImage}
             ]
         }
-
+        // Can split out paramter metadata here I think?
+        // Want to post metadata as a separate prop so we can delete before sending to Batch
         if (formData.parameters) {
             for (let param of formData.parameters) {
                 parameters[param.key] = param.defaultValue;
+                parametersMetadata[param.key] = param;
             }
         }
         jobDefinition.parameters = parameters;
+        jobDefinition.parametersMetadata = parametersMetadata;
 
         jobDefinition.descriptions = {
             description: formData.description

--- a/src/scripts/dataset/dataset.actions.js
+++ b/src/scripts/dataset/dataset.actions.js
@@ -17,6 +17,7 @@ var Actions = Reflux.createActions([
     'getFileDownloadTicket',
     'getResultDownloadTicket',
     'refreshJob',
+    'loadApps',
     'loadDataset',
     'loadSnapshot',
     'loadUsers',

--- a/src/scripts/dataset/tools/jobs/index.js
+++ b/src/scripts/dataset/tools/jobs/index.js
@@ -23,6 +23,7 @@ export default class JobMenu extends React.Component {
         this.state = {
             loading:           false,
             parameters:         {},
+            parametersMetadata: {},
             disabledApps:       {},
             jobId:              null,
             selectedApp:        [],
@@ -76,7 +77,6 @@ export default class JobMenu extends React.Component {
         let selectedAppKey = this.state.selectedAppKey;
         let selectedVersionID = this.state.selectedVersionID;
         let loadingText = this.props.loadingApps ? 'Loading pipelines' : 'Starting ' + selectedVersionID;
-
         let form = (
             <div className="anaylsis-modal clearfix">
                 {this._snapshots()}
@@ -85,7 +85,7 @@ export default class JobMenu extends React.Component {
                     ? (
                         <div>
                             <Description jobDefinition={apps[selectedAppKey][selectedVersionID]} />
-                            <Parameters parameters={this.state.parameters} subjects={this.state.subjects} onChange={this._updateParameter.bind(this)} onRestoreDefaults={this._restoreDefaultParameters.bind(this)} />
+                            <Parameters parameters={this.state.parameters} parametersMetadata={this.state.parametersMetadata} subjects={this.state.subjects} onChange={this._updateParameter.bind(this)} onRestoreDefaults={this._restoreDefaultParameters.bind(this)} />
                             {this._submit()}
                         </div>)
                     : ''
@@ -339,7 +339,8 @@ export default class JobMenu extends React.Component {
         let selectedVersionID = e.target.value;
         let selectedDefinition = this.props.apps[this.state.selectedAppKey][selectedVersionID];
         let parameters = JSON.parse(JSON.stringify(selectedDefinition.parameters));
-        this.setState({selectedVersionID, parameters});
+        let parametersMetadata = JSON.parse(JSON.stringify(selectedDefinition.parametersMetadata));
+        this.setState({selectedVersionID, parameters, parametersMetadata});
     }
 
     /**

--- a/src/scripts/dataset/tools/jobs/parameters.jsx
+++ b/src/scripts/dataset/tools/jobs/parameters.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Select from 'react-select';
 
-const JobParameters = ({parameters, subjects, onChange, onRestoreDefaults}) => {
+const JobParameters = ({parameters, subjects, onChange, onRestoreDefaults, parametersMetadata}) => {
 
     if (Object.keys(parameters).length === 0) {return <noscript />;}
 
@@ -30,7 +30,7 @@ const JobParameters = ({parameters, subjects, onChange, onRestoreDefaults}) => {
                             <div className="input-group-addon">{parameter}</div>
                             <div className="clearfix">
                                 {input}
-                                <span className="help-text">{parameter}</span>
+                                <span className="help-text">{parametersMetadata[parameter] ? parametersMetadata[parameter].description: parameter}</span>
                             </div>
                         </div>
                     </div>

--- a/src/scripts/dataset/tools/jobs/parameters.jsx
+++ b/src/scripts/dataset/tools/jobs/parameters.jsx
@@ -60,11 +60,13 @@ JobParameters.propTypes = {
     onChange: React.PropTypes.func,
     onRestoreDefaults: React.PropTypes.func,
     parameters: React.PropTypes.object,
+    parametersMetadata: React.PropTypes.object,
     subjects: React.PropTypes.array
 };
 
 JobParameters.defaultProps = {
-    parameters: {}
+    parameters: {},
+    parametersMetadata: {}
 };
 
 export default JobParameters;


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/7
* adding parameter metadata to job definitions form (for defining metadata) and to job run form to display metadata to user.
* requires crn_server branch job-def-desc
