### PR TITLE
Changing mem max to display in MiB

### DIFF
--- a/config.js
+++ b/config.js
@@ -46,7 +46,7 @@ export default {
 		aws: {
 			batch: {
 				vcpusMax: 4,
-				memoryMax: 14305.1
+				memoryMax: 15360
 			}
 		}
 };

--- a/config.js
+++ b/config.js
@@ -46,7 +46,7 @@ export default {
 		aws: {
 			batch: {
 				vcpusMax: 4,
-				memoryMax: 15
+				memoryMax: 14305.1
 			}
 		}
 };

--- a/src/scripts/admin/admin.create-job.modal.jsx
+++ b/src/scripts/admin/admin.create-job.modal.jsx
@@ -43,7 +43,7 @@ const CreateJob = React.createClass({
                         <Input placeholder="vCPUs"                   value={definition.vcpus}          name={'vcpus'}          onChange={this._inputChange} />
                         <span>{'Max number of vCPUs is ' + vcpusMax}</span>
                         <Input placeholder="Memory (MiB)"            value={definition.memory}         name={'memory'}         onChange={this._inputChange} />
-                        <span>{'Max memory is ' + memoryMax + 'GB'}</span>
+                        <span>{'Max memory is ' + memoryMax + ' MiB'}</span>
                         <div className="form-group">
                             <label>Analysis Levels</label>
                             <Select.Creatable value={definition.analysisLevels} name={'analysisLevels'} onChange={this._analysisLevelsChange} options={definition.analysisLevelOptions} multi />


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/58
* Memory max was listed in GB but input was in MiB.  Making those consistent.