### PR TITLE
Adding extradescriptions fields to app definition

### DIFF
--- a/src/scripts/admin/admin.create-job.modal.jsx
+++ b/src/scripts/admin/admin.create-job.modal.jsx
@@ -4,7 +4,7 @@ import React      from 'react';
 import Reflux     from 'reflux';
 import ArrayInput from '../common/forms/array-input.jsx';
 import Input      from '../common/forms/input.jsx';
-import {Modal}    from 'react-bootstrap';
+import {Modal, Panel, Accordion}    from 'react-bootstrap';
 import Select     from 'react-select';
 import adminStore from './admin.store';
 import actions    from './admin.actions';
@@ -26,7 +26,7 @@ const CreateJob = React.createClass({
 
     render() {
         let definition = this.state.jobDefinitionForm;
-        let title = definition.edit ? "Edit Job" : "Define a Job";
+        let title = definition.edit ? "Edit App" : "Define an App";
 
         return (
              <Modal show={this.props.show} onHide={this.props.onHide}>
@@ -36,10 +36,12 @@ const CreateJob = React.createClass({
                 <hr className="modal-inner" />
                 <Modal.Body>
                     <div>
-                        <Input placeholder="Job Definition Name"     value={definition.name}           name={'name'}           onChange={this._inputChange} disabled={!!definition.edit} />
-                        <Input placeholder="Job Definition Description" value={definition.description} name={'description'} onChange={this._inputChange} />
+                        <Input placeholder="App Definition Name"     value={definition.name}           name={'name'}           onChange={this._inputChange} disabled={!!definition.edit} />
                         <Input placeholder="Bids Container"          value={definition.containerImage} name={'containerImage'} onChange={this._inputChange} />
                         <Input placeholder="Host Container"          value={definition.hostImage}      name={'hostImage'}      onChange={this._inputChange} />
+                        <Panel header="Descriptions" collapsible defaultExpanded>
+                            {this._addDescriptions(definition)}
+                        </Panel>
                         <Input placeholder="vCPUs"                   value={definition.vcpus}          name={'vcpus'}          onChange={this._inputChange} />
                         <span>{'Max number of vCPUs is ' + vcpusMax}</span>
                         <Input placeholder="Memory (MiB)"            value={definition.memory}         name={'memory'}         onChange={this._inputChange} />
@@ -78,6 +80,16 @@ const CreateJob = React.createClass({
 
     _analysisLevelsChange (e) {
         actions.inputChange('jobDefinitionForm', 'analysisLevels', e);
+    },
+
+    _addDescriptions (definition) {
+        return (
+            [<Input placeholder="App Description" value={definition.description} name={'description'} onChange={this._inputChange} key={1}/>,
+            <Input placeholder="App short description" value={definition.shortDescription} name={'shortDescription'} onChange={this._inputChange} key={2} />,
+            <Input placeholder="Support" value={definition.support} name={'support'} onChange={this._inputChange} key={3} />,
+            <Input placeholder="Acknowledgements" value={definition.acknowledgements} name={'acknowledgements'} onChange={this._inputChange} key={4} />,
+            <Input placeholder="Tags" value={definition.tags} name={'tags'} onChange={this._inputChange} key={5} />]
+        )
     }
 });
 

--- a/src/scripts/admin/admin.jobs.jsx
+++ b/src/scripts/admin/admin.jobs.jsx
@@ -16,7 +16,7 @@ let Jobs = React.createClass({
 // life cycle events --------------------------------------------------
 
     render() {
-        let noJobs = <div className="no-results">There are no jobs defined.</div>;
+        let noJobs = <div className="no-results">There are no apps defined.</div>;
         let jobs = batch.filterJobDefinitions(this.state.datasets.apps).map((app, index) => {
             let bidsContainer = batch.getBidsContainer(app);
             return (
@@ -56,14 +56,14 @@ let Jobs = React.createClass({
         return (
             <div className="dashboard-dataset-teasers fade-in inner-route admin-jobs clearfix">
                 <div className="clearfix">
-                    <h2>Job Definitions</h2>
+                    <h2>App Definitions</h2>
                     <button className="btn-blue" onClick={actions.toggleModal.bind(this, 'defineJob')} >
-                        <span>Define a Job</span>
+                        <span>Define an App</span>
                     </button>
                 </div>
                 <div className="col-xs-12 job-panel-wrap">
                         <div className="fade-in job-panel-header clearfix" >
-                            <div className="col-xs-5 job-col"><label>Job</label></div>
+                            <div className="col-xs-5 job-col"><label>App</label></div>
                             <div className="col-xs-3 job-col"><label>Container Image</label></div>
                             <div className="col-xs-2 job-col"><label>Status</label></div>
                             <div className="col-xs-2 job-col"><label>Actions</label></div>

--- a/src/scripts/admin/admin.jsx
+++ b/src/scripts/admin/admin.jsx
@@ -22,7 +22,7 @@ class Dashboard extends React.Component {
                     <ul className="nav nav-pills tabs">
                         <li><Link to="users" className="btn-tab">Users</Link></li>
                         <li><Link to="blacklist" className="btn-tab">Blocked Users</Link></li>
-                        <li><Link to="job-definitions" className="btn-tab">Job Definitions</Link></li>
+                        <li><Link to="job-definitions" className="btn-tab">App Definitions</Link></li>
                     </ul>
                     <RouteHandler/>
                 </div>

--- a/src/scripts/admin/admin.store.js
+++ b/src/scripts/admin/admin.store.js
@@ -68,7 +68,11 @@ let UserStore = Reflux.createStore({
                 analysisLevelOptions: [],
                 parameters: [],
                 edit: false,
-                description: ''
+                description: '',
+                shortDescription: '',
+                acknowledgements:'',
+                tags:'',
+                support:''
             },
             blacklistError: ''
         };
@@ -294,7 +298,11 @@ let UserStore = Reflux.createStore({
         jobDefinition.analysisLevels = formData.analysisLevels;
 
         jobDefinition.descriptions = {
-            description: formData.description
+            description: formData.description,
+            shortDescription: formData.shortDescription,
+            acknowledgements: formData.acknowledgements,
+            support: formData.support,
+            tags: formData.tags
         };
 
         crn.defineJob(jobDefinition, (err) => {
@@ -338,6 +346,10 @@ let UserStore = Reflux.createStore({
         jobDefinitionForm.edit = true;
         jobDefinitionForm.name = jobDefinition.jobDefinitionName;
         jobDefinitionForm.description = jobDefinition.descriptions && jobDefinition.descriptions.description ? jobDefinition.descriptions.description : '';
+        jobDefinitionForm.shortDescription = jobDefinition.descriptions && jobDefinition.descriptions.shortDescription ? jobDefinition.descriptions.shortDescription : '';
+        jobDefinitionForm.acknowledgements = jobDefinition.descriptions && jobDefinition.descriptions.acknowledgements ? jobDefinition.descriptions.acknowledgements : '';
+        jobDefinitionForm.support = jobDefinition.descriptions && jobDefinition.descriptions.support ? jobDefinition.descriptions.support : '';
+        jobDefinitionForm.tags = jobDefinition.descriptions && jobDefinition.descriptions.tags ? jobDefinition.descriptions.tags : '';
         jobDefinitionForm.jobRoleArn = jobDefinition.jobDefinitionArn;
         jobDefinitionForm.containerImage = batch.getBidsContainer(jobDefinition);
         jobDefinitionForm.hostImage = jobDefinition.containerProperties.image;
@@ -381,7 +393,11 @@ let UserStore = Reflux.createStore({
             analysisLevels: [],
             analysisLevelOptions: [],
             parameters: [],
-            edit: false
+            edit: false,
+            shortDescription: '',
+            acknowledgements:'',
+            tags:'',
+            support:''
         };
 
         this.update({jobDefinitionForm});

--- a/src/scripts/dataset/tools/jobs/description.jsx
+++ b/src/scripts/dataset/tools/jobs/description.jsx
@@ -5,63 +5,56 @@ import markdown from '../../../utils/markdown';
 
 
 const JobDescription = ({jobDefinition}) => {
+    let descriptions = jobDefinition.descriptions;
 
     let shortDescription;
-    if (jobDefinition.shortDescription) {
+    if (descriptions && descriptions.shortDescription) {
         shortDescription = (
             <div>
                 <h5>Short Description</h5>
-                <div className="well" dangerouslySetInnerHTML={markdown.format(jobDefinition.shortDescription)}></div>
-            </div>
-        );
-    }
-
-    let help;
-    if (jobDefinition.helpURI) {
-        help = (
-            <div>
-                <h5>Help</h5>
-                <div className="well">
-                    <a href={jobDefinition.helpURI} target="_blank">{jobDefinition.helpURI}</a>
-                </div>
+                <div className="well" dangerouslySetInnerHTML={markdown.format(descriptions.shortDescription)}></div>
             </div>
         );
     }
 
     let tags;
-    if (jobDefinition.tags) {
+    if (descriptions && descriptions.tags) {
         tags = (
             <div>
                 <h5>Tags</h5>
-                <div className="well">{jobDefinition.tags.join(', ')}</div>
+                <div className="well">{descriptions.tags}</div>
             </div>
         );
     }
 
-    let description,
-        acknowledgments,
-        support;
-    if (jobDefinition.longDescription) {
-        jobDefinition.longDescription = typeof jobDefinition.longDescription === 'string' ? JSON.parse(jobDefinition.longDescription) : jobDefinition.longDescription;
+    let description;
+    if (descriptions && descriptions.description) {
+        // descriptions.description = typeof descriptions.description === 'string' ? JSON.parse(descriptions.description) : descriptions.description;
 
         description = (
             <div>
                 <h5>Description</h5>
-                <div className="well" dangerouslySetInnerHTML={markdown.format(jobDefinition.longDescription.description)}></div>
+                <div className="well" dangerouslySetInnerHTML={markdown.format(descriptions.description)}></div>
             </div>
         );
+    }
 
+    let acknowledgments;
+    if (descriptions && descriptions.acknowledgments) {
         acknowledgments = (
             <div>
                 <h5>Acknowledgements</h5>
-                <div className="well" dangerouslySetInnerHTML={markdown.format(jobDefinition.longDescription.acknowledgments)}></div>
+                <div className="well" dangerouslySetInnerHTML={markdown.format(descriptions.acknowledgments)}></div>
             </div>
         );
+    }
 
+    let support;
+    if (descriptions && descriptions.support) {
         support = (
             <div>
                 <h5>Support</h5>
-                <div className="well" dangerouslySetInnerHTML={markdown.format(jobDefinition.longDescription.support)}></div>
+                <div className="well" dangerouslySetInnerHTML={markdown.format(descriptions.support)}></div>
             </div>
         );
     }
@@ -72,7 +65,6 @@ const JobDescription = ({jobDefinition}) => {
             {shortDescription}
             {description}
             {acknowledgments}
-            {help}
             {support}
             {tags}
         </div>


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/6 and https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/46
* Adding a collapsible list of inputs for descriptions we want to support.
* Update descriptions in analysis modal to display the new definitions "model"
* updated some UI wording to refer to a job definition as an App.  code still has variables using job definition terminology.  
