### PR TITLE
Use the dataset subjects as a default value for participant_label

### DIFF
--- a/src/scripts/dataset/dataset.store.js
+++ b/src/scripts/dataset/dataset.store.js
@@ -972,6 +972,14 @@ let datasetStore = Reflux.createStore({
      */
     startJob(snapshotId, jobDefinition, parameters, callback) {
         let datasetId = this.data.dataset.original ? this.data.dataset.original : this.data.dataset._id;
+
+        // If the participant_label parameter exists and has no value, use all subjects
+        if (parameters.hasOwnProperty('participant_label') &&
+            parameters.participant_label.length === 0) {
+            console.log(this.data);
+            parameters.participant_label = this.data.dataset.summary.subjects;
+        }
+
         crn.createJob({
             datasetId:     datasetId,
             datasetLabel:  this.data.dataset.label,
@@ -1083,7 +1091,7 @@ let datasetStore = Reflux.createStore({
             let downloadUrl = config.crn.url + 'jobs/' + jobId + '/results/' + "fileName" + '?ticket=' + 'ticket';
             callback(downloadUrl)
         } else {
-            callback('https://s3.amazonaws.com/' + filePath);    
+            callback('https://s3.amazonaws.com/' + filePath);
         }
     },
 

--- a/src/scripts/dataset/dataset.store.js
+++ b/src/scripts/dataset/dataset.store.js
@@ -976,7 +976,6 @@ let datasetStore = Reflux.createStore({
         // If the participant_label parameter exists and has no value, use all subjects
         if (parameters.hasOwnProperty('participant_label') &&
             parameters.participant_label.length === 0) {
-            console.log(this.data);
             parameters.participant_label = this.data.dataset.summary.subjects;
         }
 


### PR DESCRIPTION
This value has to be passed to the server so it can divide up the participant analysis levels into separate jobs. Rather than try to handle getting this list in the server, it seems simpler but a bit hacky to just populate it before we send the job if participant_label is defined and empty.