### PR TITLE
Exclude Inactive Versions from Select

### DIFF
--- a/src/scripts/dataset/tools/jobs/index.js
+++ b/src/scripts/dataset/tools/jobs/index.js
@@ -150,7 +150,7 @@ export default class JobMenu extends React.Component {
             let disabled = this.state.disabledApps.hasOwnProperty(apps[selectedApp][revision].jobDefinitionArn) ? '* ' : '';
             return active ? <option key={revision} value={revision}>{disabled + 'v' + revision}</option> :  null;
         }) : [];
-        console.log(versionOptions);
+
         const versions = (
             <div className="col-xs-12">
                 <div className="row">

--- a/src/scripts/dataset/tools/jobs/index.js
+++ b/src/scripts/dataset/tools/jobs/index.js
@@ -146,10 +146,12 @@ export default class JobMenu extends React.Component {
         });
 
         const versionOptions = selectedApp ? Object.keys(apps[selectedApp]).reverse().map((revision) => {
+            let active = apps[selectedApp][revision].status === 'ACTIVE';
+            console.log(apps[selectedApp][revision])
             let disabled = this.state.disabledApps.hasOwnProperty(apps[selectedApp][revision].jobDefinitionArn) ? '* ' : '';
-            return <option key={revision} value={revision}>{disabled + 'v' + revision}</option>;
+            return active ? <option key={revision} value={revision}>{disabled + 'v' + revision}</option> :  null;
         }) : [];
-
+        console.log(versionOptions);
         const versions = (
             <div className="col-xs-12">
                 <div className="row">

--- a/src/scripts/dataset/tools/jobs/index.js
+++ b/src/scripts/dataset/tools/jobs/index.js
@@ -147,7 +147,6 @@ export default class JobMenu extends React.Component {
 
         const versionOptions = selectedApp ? Object.keys(apps[selectedApp]).reverse().map((revision) => {
             let active = apps[selectedApp][revision].status === 'ACTIVE';
-            console.log(apps[selectedApp][revision])
             let disabled = this.state.disabledApps.hasOwnProperty(apps[selectedApp][revision].jobDefinitionArn) ? '* ' : '';
             return active ? <option key={revision} value={revision}>{disabled + 'v' + revision}</option> :  null;
         }) : [];


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/65
* Removing the option to select inactive job definitions from the job run select form.