### PR TITLE
Support for retry

### DIFF
--- a/src/scripts/dataset/dataset.jobs.run.jsx
+++ b/src/scripts/dataset/dataset.jobs.run.jsx
@@ -147,7 +147,7 @@ class JobAccordion extends React.Component {
                         icon="fa fa-repeat"
                         message="re-run"
                         warn={false}
-                        action={actions.retryJob.bind(this, run.jobId)} />
+                        action={actions.retryJob.bind(this, run._id)} />
                 </div>
             );
         }

--- a/src/scripts/dataset/dataset.store.js
+++ b/src/scripts/dataset/dataset.store.js
@@ -985,7 +985,7 @@ let datasetStore = Reflux.createStore({
                 });
             }
         };
-        setTimeout(poll.bind(this, jobId), interval);
+        poll(jobId);
     },
 
     /**
@@ -1013,7 +1013,6 @@ let datasetStore = Reflux.createStore({
             if (!err) {
                 // reload jobs
                 if (snapshotId == this.data.dataset._id) {
-                    // let jobId = res.body.result.id;
                     let jobId = res.body.jobId;
                     this.loadJobs(snapshotId, this.data.snapshot, datasetId, {job: jobId}, (jobs) => {
                         this.loadSnapshots(this.data.dataset, jobs);
@@ -1064,6 +1063,9 @@ let datasetStore = Reflux.createStore({
         crn.retryJob(this.data.dataset._id, jobId, () => {
             this.loadJobs(this.data.dataset._id, true, this.data.dataset.original, {}, (jobs) => {
                 this.loadSnapshots(this.data.dataset, jobs);
+
+                // start polling job
+                this.pollJob(jobId, this.data.selectedSnapshot);
                 callback();
             });
         }, {snapshot: this.data.snapshot});


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/106 along with https://github.com/poldracklab/crn_server/pull/87
* also changed first poll after job submission to be immediate as opposed to delayed 5 seconds.  subsequent polls are still on 5 sec intervals.  
* requires server branch of same name retry-job