### PR TITLE
Fix uncaught type error during disable and edit of app defs

### DIFF
--- a/src/scripts/admin/admin.apps.jsx
+++ b/src/scripts/admin/admin.apps.jsx
@@ -79,8 +79,8 @@ let Apps = React.createClass({
                         </div>
                         <div className="col-xs-3  job-col last">
                             <div className="tools clearfix">
-                                <button className="tool cte-edit-button btn btn-admin fade-in" onClick={actions.editJobDefinition.bind(this, app)} ><i className="fa fa-pencil" ></i> Edit </button>
-                                <button className="tool cte-edit-button btn btn-admin fade-in" onClick={actions.disableJobDefinition.bind(this, app)} ><i className="fa fa-ban" ></i> Disable</button>
+                                <button className="tool cte-edit-button btn btn-admin fade-in" onClick={this._editJobDefinition.bind(this, app)} ><i className="fa fa-pencil" ></i> Edit </button>
+                                <button className="tool cte-edit-button btn btn-admin fade-in" onClick={this._disableJobDefinition.bind(this, app)} ><i className="fa fa-ban" ></i> Disable</button>
                             </div>
                         </div>
                     </div>
@@ -89,6 +89,14 @@ let Apps = React.createClass({
         });
 
         return list;
+    },
+
+    _editJobDefinition(app) {
+        actions.editJobDefinition(app);
+    },
+
+    _disableJobDefinition(app) {
+        actions.disableJobDefinition(app);
     }
 
 });

--- a/src/scripts/admin/admin.store.js
+++ b/src/scripts/admin/admin.store.js
@@ -330,6 +330,7 @@ let UserStore = Reflux.createStore({
         crn.disableJobDefinition(name, jobArn, (err, data) => {
             //TODO Update job list
             console.log('Job disabled');
+            datasetActions.loadApps(); //need to reload apps for UI to update with Inactive status on disable
             if(callback){
                 callback();
             }


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/115
* were getting uncaught errors from click handlers during disable and edit app defs. Eliminated "event" arguments from being sent to actions to resolve the issue
* also noticed we were not reloading apps on disable and therefore the status in the UI was not getting updated unless there was a refresh.  Fixed this issue as well.