### PR TITLE
Making job polling interval random between 20 and 40 seconds

### DIFF
--- a/src/scripts/dataset/dataset.store.js
+++ b/src/scripts/dataset/dataset.store.js
@@ -969,7 +969,6 @@ let datasetStore = Reflux.createStore({
     },
 
     pollJob(jobId, snapshotId) {
-        let interval = 5000;
         let poll = (jobId) => {
             if (this.data.dataset && this.data.dataset._id === snapshotId) {
                 this.refreshJob(jobId, (job) => {
@@ -980,6 +979,7 @@ let datasetStore = Reflux.createStore({
                     let needsUpdate = (!finished && !failed) || (finished && !hasResults);
 
                     if (needsUpdate && this.data.dataset && job.snapshotId === this.data.dataset._id) {
+                        let interval = this._getInterval(20000, 40000); // random interval between 20 and 40 seconds
                         setTimeout(poll.bind(this, jobId), interval);
                     }
                 });
@@ -1253,6 +1253,10 @@ let datasetStore = Reflux.createStore({
         if (typeof value === 'boolean') {showSidebar = value;}
         window.localStorage.showSidebar = showSidebar;
         this.update({showSidebar});
+    },
+
+    _getInterval (min, max) {
+        return Math.floor(Math.random() * (max - min + 1)) + min;
     }
 
 });


### PR DESCRIPTION
* will hopefully alleviate some of the issues seen here https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/132
* on each poll, the interval will be chosen randomly (between 20 and 40 seconds)
* this is intended to spread out the polling calls and keep them from stacking up