### PR TITLE
Make pipeline option text black to ensure they show up on linux windows

### DIFF
--- a/src/sass/crn_app/_frontPage.scss
+++ b/src/sass/crn_app/_frontPage.scss
@@ -402,6 +402,10 @@
                     position: relative;
                 }
 
+                .select-pipeline option {
+                    color: black;
+                }
+
                 .select-pipeline-arrow{
                     border-color: $white rgba(0, 0, 0, 0) rgba(0, 0, 0, 0);
                     border-style: solid;


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/128
* adding a class for pipeline option elements to explicitly set them to black.  
* tested on windows vm and text is as shown below.
![image](https://user-images.githubusercontent.com/5668826/27060469-e88e2c92-4f91-11e7-80f6-0b74b1a4f677.png)
