### PR TITLE
Fix skipped validation errors when quickTest fails in the validator

### DIFF
--- a/src/scripts/upload/upload.error-link.jsx
+++ b/src/scripts/upload/upload.error-link.jsx
@@ -67,7 +67,7 @@ export default class ErrorLink extends React.Component {
 }
 
 ErrorLink.propTypes = {
-    errors:React.PropTypes.array,
+    errors:React.PropTypes.oneOfType([React.PropTypes.array,React.PropTypes.string]),
     warnings:React.PropTypes.array,
     dirName:React.PropTypes.string
 };

--- a/src/scripts/upload/upload.issues.jsx
+++ b/src/scripts/upload/upload.issues.jsx
@@ -12,7 +12,7 @@ let Issues = React.createClass({
 // life cycle events --------------------------------------------------
     propTypes: {
         tree:React.PropTypes.array,
-        errors:React.PropTypes.array,
+        errors:React.PropTypes.oneOfType([React.PropTypes.array,React.PropTypes.string]),
         warnings:React.PropTypes.array,
         dirName:React.PropTypes.string,
         uploadStatus:React.PropTypes.string

--- a/src/scripts/upload/upload.store.js
+++ b/src/scripts/upload/upload.store.js
@@ -178,21 +178,24 @@ let UploadStore = Reflux.createStore({
             validate.BIDS(list, {}, (issues, summary) => {
 
                 if (issues === 'Invalid') {
-                    this.update({errors: 'Invalid'});
-                }
+                    this.update({
+                        errors: 'Invalid',
+                        uploadStatus: 'validated'
+                    });
+                } else {
+                    let errors   = issues.errors   ? issues.errors   : [];
+                    let warnings = issues.warnings ? issues.warnings : [];
 
-                let errors   = issues.errors   ? issues.errors   : [];
-                let warnings = issues.warnings ? issues.warnings : [];
+                    this.update({
+                        errors: errors,
+                        warnings: warnings,
+                        summary: summary,
+                        uploadStatus: 'validated'
+                    });
 
-                this.update({
-                    errors: errors,
-                    warnings: warnings,
-                    summary: summary,
-                    uploadStatus: 'validated'
-                });
-
-                if (errors.length === 0 && warnings.length === 0) {
-                    this.checkExists();
+                    if (errors.length === 0 && warnings.length === 0) {
+                        this.checkExists();
+                    }
                 }
             });
         });

--- a/src/scripts/upload/upload.validation-results.jsx
+++ b/src/scripts/upload/upload.validation-results.jsx
@@ -72,7 +72,6 @@ ValidationResults.Props = {
 
 
 ValidationResults.propTypes = {
-    errors: React.PropTypes.array,
+    errors: React.PropTypes.oneOfType([React.PropTypes.array,React.PropTypes.string]),
     warnings: React.PropTypes.array
 };
-


### PR DESCRIPTION
The quick test step for the BIDS validator was getting skipped because these two issues. This should stop users from uploading completely random sets of files that fail the quick test and lead to later bugs with those bogus datasets.