### PR TITLE
Fix the file upload validation when the issue does not include file info

### DIFF
--- a/src/scripts/upload/upload.error-link.jsx
+++ b/src/scripts/upload/upload.error-link.jsx
@@ -52,7 +52,7 @@ export default class ErrorLink extends React.Component {
             for (var j = 0; j < issues[i].files.length; j++) {
                 var file = issues[i].files[j];
                 issueString += '\tType:\t\t' + type + '\n';
-                if (!file) {continue;}
+                if (!(file && file.file)) {continue;}
                 if (file.file.name)    {issueString += '\tFile:\t\t' + file.file.name + '\n';}
                 if (file.file.webkitRelativePath)    {issueString += '\tLocation:\t\t' + file.file.webkitRelativePath + '\n';}
                 if (file.reason)    {issueString += '\tReason:\t\t' + file.reason + '\n';}

--- a/src/scripts/upload/upload.validation-results.issues.issue.jsx
+++ b/src/scripts/upload/upload.validation-results.issues.issue.jsx
@@ -10,8 +10,7 @@ export default class Issue extends React.Component {
 
     render () {
         let error = this.props.error;
-        let fileName = error.file && error.file.name ? error.file.name : error.file.relativePath.split('/')[error.file.relativePath.split('/').length - 1];
-
+        let fileInfo;
         // build error location string
         let errLocation = '';
         let  errorLocationMeta;
@@ -28,14 +27,20 @@ export default class Issue extends React.Component {
                 </span>
             );
         }
-    
+
+        // Check if this issue has an file associated with it at all
+        if (error.file) {
+            fileInfo = (
+                <span>
+                    {this._fileName(error.file)}
+                    {this._fileMetadata(error.file)}
+                </span>
+            );
+        }
+
         return (
             <div className="em-body">
-                <span className="e-meta">
-                    <label>File Name:</label>
-                    <p>{fileName}</p>
-                </span>
-                {this._fileMetadata(error.file)}
+                {fileInfo}
                 <span className="e-meta">
                     {this._location(error.file)}
                     <label>Reason: </label>
@@ -47,6 +52,18 @@ export default class Issue extends React.Component {
     }
 
 // custom methods -----------------------------------------------------
+
+    _fileName(file) {
+        let fileName = file.name ? file.name : file.relativePath.split('/')[file.relativePath.split('/').length - 1];
+        if (fileName) {
+            return (
+                <span className="e-meta">
+                    <label>File Name:</label>
+                    <p>{fileName}</p>
+                </span>
+            );
+        }
+    }
 
     _fileMetadata(file) {
         if (file.size) {
@@ -60,7 +77,7 @@ export default class Issue extends React.Component {
     }
 
     _location(file) {
-        if (file.webkitRelativePath) {
+        if (file && file.webkitRelativePath) {
             return (
                 <span>
                     <label>Location: </label>


### PR DESCRIPTION
Some issues are returned without a file or path, which previously would crash the uploader. This should display the error without the missing file info and include it properly in the downloadable issues log.