### PR TITLE
Limit who can delete datasets/snapshots

### DIFF
--- a/src/scripts/dataset/tools/index.js
+++ b/src/scripts/dataset/tools/index.js
@@ -34,7 +34,6 @@ let Tools = React.createClass({
 
         let datasetHasJobs = !!this.props.dataset.jobs.length;
 
-console.log(dataset);
         // permission check shorthands
         let isAdmin      = dataset.access === 'admin',
             // isEditor     = dataset.access === 'rw',

--- a/src/scripts/dataset/tools/index.js
+++ b/src/scripts/dataset/tools/index.js
@@ -32,6 +32,9 @@ let Tools = React.createClass({
         let dataset     = this.props.dataset,
             snapshots   = this.props.snapshots;
 
+        let datasetHasJobs = !!this.props.dataset.jobs.length;
+
+console.log(dataset);
         // permission check shorthands
         let isAdmin      = dataset.access === 'admin',
             // isEditor     = dataset.access === 'rw',
@@ -41,7 +44,9 @@ let Tools = React.createClass({
             isIncomplete = !!dataset.status.incomplete,
             isInvalid    = !!dataset.status.invalid,
             isSnapshot   = !!dataset.original,
-            isSuperuser  = window.localStorage.scitranUser ? JSON.parse(window.localStorage.scitranUser).root : null;
+            isSuperuser  = window.localStorage.scitran ? JSON.parse(window.localStorage.scitran).root : null;
+
+        let displayDelete = this._deleteDataset(isAdmin, isPublic, isSuperuser, datasetHasJobs);
 
         let tools = [
             {
@@ -69,7 +74,7 @@ let Tools = React.createClass({
                 tooltip: isSnapshot ? 'Delete Snapshot' : 'Delete Dataset',
                 icon: 'fa-trash',
                 action: actions.deleteDataset.bind(this, dataset._id),
-                display: (isAdmin && !isPublic) || isSuperuser,
+                display: displayDelete,
                 warn: isSnapshot
             },
             {
@@ -148,6 +153,25 @@ let Tools = React.createClass({
             }
         });
         return tools;
+    },
+
+    _deleteDataset(isAdmin, isPublic, isSuperuser, datasetHasJobs) {
+        //CRN admin can delete any dataset 
+        if(isSuperuser) {
+            return true;
+        }
+        // If user is not a CRN admin and the dataset has jobs associated with it, don't allow deletion.
+        if(datasetHasJobs) {
+            return false;
+        }
+        // If user is not a CRN admin, there are no jobs associated with dataset and the dataset is not public,
+        // and the user has been given admin access (this is different than CRN admin) to the shared dataset
+        // allow deletion
+        if(isAdmin && !isPublic) {
+            return true;
+        }
+        //otherwise don't allow deletion
+        return false
     }
 
 });


### PR DESCRIPTION
* resolves https://gitlab.sqm.io/stanford_crn/Data-Processing-Engine/issues/154
* adding some logic to determine whether a given snapshot or dataset can be deleted by a user.